### PR TITLE
fix: sample placeholder size

### DIFF
--- a/cli/plugins/scaling.py
+++ b/cli/plugins/scaling.py
@@ -109,12 +109,7 @@ async def invoke_batch(nb, lambda_name, version, memory_mb):
 def run(c, nb=128, memory_mb=2048):
     """Run "nb" Lambdas with "memory_mb" size"""
     lambda_names = terraform_output(c, "scaling", "lambda_names").split(",")
-    random.shuffle(lambda_names)
-
-    results = []
-    for lambda_name in lambda_names:
-        version = resize(lambda_name, memory_mb)
-        res = asyncio.run(invoke_batch(nb, lambda_name, version, memory_mb))
-        results.append(res)
-
-    return results
+    picked_lambda = random.choice(lambda_names)
+    version = resize(picked_lambda, memory_mb)
+    res = asyncio.run(invoke_batch(nb, picked_lambda, version, memory_mb))
+    return [res]


### PR DESCRIPTION
### :newspaper: PR description

Current infra run cost is ~ $5 per day. Running the scaling tests for all placeholder sizes actually doesn't bring much value as performances are constanct on that dimension. Sample just one instead.

### :memo: Reviewer instructions

<!--
Provide indications to the reviewer:
- where should he start?
- are their changes that are side effects to the original PR objective?
-->
