### PR TITLE
feat(Chappy): add shutdown hook to perforator

### DIFF
--- a/chappy/Cargo.lock
+++ b/chappy/Cargo.lock
@@ -174,7 +174,6 @@ dependencies = [
  "nix",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -193,7 +192,6 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -208,7 +206,6 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -1273,6 +1270,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,6 +1450,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.4.7",
  "tokio-macros",
  "windows-sys 0.42.0",

--- a/chappy/interceptor/Cargo.toml
+++ b/chappy/interceptor/Cargo.toml
@@ -17,4 +17,3 @@ libloading = { workspace = true }
 nix = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }

--- a/chappy/perforator/Cargo.toml
+++ b/chappy/perforator/Cargo.toml
@@ -12,8 +12,7 @@ quinn = { workspace = true }
 rcgen = { workspace = true }
 rustls = { workspace = true, features = ["quic"] }
 socket2 = { workspace = true, features = ["all"] }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "signal"] }
 tonic = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }

--- a/chappy/perforator/src/lib.rs
+++ b/chappy/perforator/src/lib.rs
@@ -4,6 +4,7 @@ pub mod forwarder;
 pub mod perforator;
 pub mod protocol;
 pub mod quic_utils;
+pub mod shutdown;
 pub mod udp_utils;
 
 #[macro_use]

--- a/chappy/perforator/src/main.rs
+++ b/chappy/perforator/src/main.rs
@@ -1,53 +1,67 @@
 use chappy_perforator::{
-    binding_service::BindingService, forwarder::Forwarder, perforator::Perforator,
-    protocol::ParsedTcpStream, CHAPPY_CONF,
+    binding_service::BindingService,
+    forwarder::Forwarder,
+    perforator::Perforator,
+    protocol::ParsedTcpStream,
+    shutdown::{gracefull, GracefullyRunnable, Shutdown},
+    CHAPPY_CONF,
 };
-use chappy_util::CustomTime;
-use tracing::{debug_span, info, Instrument};
-use tracing_subscriber::EnvFilter;
-
+use chappy_util::init_tracing;
 use std::sync::Arc;
 use tokio::net::TcpListener;
+use tonic::async_trait;
+use tracing::{debug_span, info, Instrument};
+
+struct SrvRunnable;
+
+#[async_trait]
+impl GracefullyRunnable for SrvRunnable {
+    async fn run(&self, shutdown: &Shutdown) {
+        let tcp_port = 5000;
+        let seed_addr = format!("{}:{}", CHAPPY_CONF.seed_hostname, CHAPPY_CONF.seed_port);
+        let (cli_quic_port, srv_quic_port) = (5001, 5002);
+        info!(
+            perforator_tcp_port = tcp_port,
+            perforator_quic_client_port = cli_quic_port,
+            perforator_quic_server_port = srv_quic_port,
+            seed_address = %seed_addr
+        );
+        let listener = TcpListener::bind(format!("127.0.0.1:{}", tcp_port))
+            .await
+            .unwrap();
+        let forwarder = Forwarder::new(cli_quic_port, srv_quic_port);
+        let binding_service = BindingService::new(cli_quic_port, srv_quic_port);
+        let perforator = Arc::new(Perforator::new(forwarder, binding_service));
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            let src_port = stream.peer_addr().unwrap().port();
+            let perforator = Arc::clone(&perforator);
+            let shutdown_guard = shutdown.create_guard();
+            tokio::spawn(
+                async move {
+                    let parsed_stream = ParsedTcpStream::from(stream).await;
+                    match parsed_stream {
+                        ParsedTcpStream::ClientRegistration {
+                            source_port,
+                            target_virtual_ip,
+                            target_port,
+                        } => {
+                            perforator.register_client(source_port, target_virtual_ip, target_port)
+                        }
+                        ParsedTcpStream::ServerRegistration => perforator.register_server(),
+                        ParsedTcpStream::Raw(stream) => {
+                            perforator.forward_conn(stream, shutdown_guard).await
+                        }
+                    }
+                }
+                .instrument(debug_span!("tcp", src_port)),
+            );
+        }
+    }
+}
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .with_writer(std::io::stderr)
-        .with_timer(CustomTime)
-        .init();
-    let tcp_port = 5000;
-    let tcp_addr = format!("127.0.0.1:{}", tcp_port);
-    let seed_addr = format!("{}:{}", CHAPPY_CONF.seed_hostname, CHAPPY_CONF.seed_port);
-    let (cli_quic_port, srv_quic_port) = (5001, 5002);
-    info!(
-        perforator_tcp_address = %tcp_addr,
-        perforator_quic_client_port = cli_quic_port,
-        perforator_quic_server_port = srv_quic_port,
-        seed_address = %seed_addr
-    );
-    let listener = TcpListener::bind(tcp_addr).await.unwrap();
-    let forwarder = Forwarder::new(cli_quic_port, srv_quic_port);
-    let binding_service = BindingService::new(cli_quic_port, srv_quic_port);
-    let perforator = Arc::new(Perforator::new(forwarder, binding_service));
-    loop {
-        let (stream, _) = listener.accept().await.unwrap();
-        let src_port = stream.peer_addr().unwrap().port();
-        let perforator = Arc::clone(&perforator);
-        tokio::spawn(
-            async move {
-                let parsed_stream = ParsedTcpStream::from(stream).await;
-                match parsed_stream {
-                    ParsedTcpStream::ClientRegistration {
-                        source_port,
-                        target_virtual_ip,
-                        target_port,
-                    } => perforator.register_client(source_port, target_virtual_ip, target_port),
-                    ParsedTcpStream::ServerRegistration => perforator.register_server(),
-                    ParsedTcpStream::Raw(stream) => perforator.forward_conn(stream).await,
-                }
-            }
-            .instrument(debug_span!("tcp", src_port)),
-        );
-    }
+    init_tracing();
+    gracefull(SrvRunnable).await;
 }

--- a/chappy/perforator/src/perforator.rs
+++ b/chappy/perforator/src/perforator.rs
@@ -1,4 +1,6 @@
-use crate::{binding_service::BindingService, forwarder::Forwarder, udp_utils};
+use crate::{
+    binding_service::BindingService, forwarder::Forwarder, shutdown::ShutdownGuard, udp_utils,
+};
 use chappy_seed::Address;
 
 use futures::StreamExt;
@@ -80,8 +82,8 @@ impl Perforator {
     }
 
     /// Forward a TCP stream from a registered port
-    #[instrument(name = "fwd_conn", skip_all, fields())]
-    pub async fn forward_conn(&self, stream: TcpStream) {
+    #[instrument(name = "fwd_conn", skip_all)]
+    pub async fn forward_conn(&self, stream: TcpStream, _shdn: ShutdownGuard) {
         debug!("starting...");
         let src_port = stream.peer_addr().unwrap().port();
         let target_virtual_address = self

--- a/chappy/perforator/src/shutdown.rs
+++ b/chappy/perforator/src/shutdown.rs
@@ -1,0 +1,59 @@
+use std::time::Duration;
+use tokio::signal::unix::{signal, SignalKind};
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+use tonic::async_trait;
+use tracing::{info, warn};
+
+pub struct ShutdownGuard {
+    _guard: mpsc::Sender<()>,
+}
+
+pub struct Shutdown {
+    guard: mpsc::Sender<()>,
+    waiter: mpsc::Receiver<()>,
+}
+
+impl Shutdown {
+    pub fn new() -> Self {
+        let (guard, waiter) = mpsc::channel(1);
+        Self { guard, waiter }
+    }
+
+    pub fn create_guard(&self) -> ShutdownGuard {
+        ShutdownGuard {
+            _guard: self.guard.clone(),
+        }
+    }
+
+    pub async fn wait(self) {
+        let Self { guard, mut waiter } = self;
+        drop(guard);
+        let _ = waiter.recv().await;
+    }
+}
+
+#[async_trait]
+pub trait GracefullyRunnable {
+    async fn run(&self, shutdown: &Shutdown);
+}
+
+pub async fn gracefull(runnable: impl GracefullyRunnable) {
+    let shutdown = Shutdown::new();
+    let mut sigterm = signal(SignalKind::terminate()).unwrap();
+    let mut sigint = signal(SignalKind::interrupt()).unwrap();
+    tokio::select! {
+        _ = runnable.run(&shutdown) => {}
+        _ = sigint.recv()=> {
+            info!("SIGINT received, exiting gracefully...")
+        }
+        _ = sigterm.recv()=> {
+            info!("SIGTERM received, exiting gracefully...")
+        }
+    }
+
+    match timeout(Duration::from_secs(1), shutdown.wait()).await {
+        Ok(_) => info!("Gracefull shutdown completed"),
+        Err(_) => warn!("Grace period elapsed, forcefully shutting down"),
+    }
+}

--- a/chappy/seed/Cargo.toml
+++ b/chappy/seed/Cargo.toml
@@ -12,7 +12,6 @@ tokio = { workspace = true, features = ["rt"] }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 
 
 [build-dependencies]

--- a/chappy/seed/src/main.rs
+++ b/chappy/seed/src/main.rs
@@ -1,17 +1,12 @@
 use chappy_seed::{seed_server::SeedServer, seed_service::SeedService};
-use chappy_util::CustomTime;
+use chappy_util::init_tracing;
 use std::env;
 use tonic::{transport::Server, Result};
 use tracing::debug;
-use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .with_writer(std::io::stderr)
-        .with_timer(CustomTime)
-        .init();
+    init_tracing();
     let port = env::var("PORT").unwrap();
     debug!("Starting seed on port {}...", port);
     let service = SeedService::new();

--- a/chappy/util/src/lib.rs
+++ b/chappy/util/src/lib.rs
@@ -1,11 +1,32 @@
 use chrono::prelude::{DateTime, Utc};
 use tracing_subscriber::fmt::{format::Writer, time::FormatTime};
+use tracing_subscriber::EnvFilter;
 
-pub struct CustomTime;
+struct CustomTime;
 
 impl FormatTime for CustomTime {
     fn format_time(&self, w: &mut Writer<'_>) -> core::fmt::Result {
         let dt: DateTime<Utc> = std::time::SystemTime::now().into();
         write!(w, "{}", dt.format("%H:%M:%S%.3f"))
     }
+}
+
+/// Configure and init tracing for executables
+pub fn init_tracing() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .with_timer(CustomTime)
+        .init();
+}
+
+/// Configure and init tracing with some tweeks specific to shared libraries
+pub fn init_tracing_shared_lib() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .with_target(false)
+        .with_timer(CustomTime)
+        .try_init()
+        .ok();
 }


### PR DESCRIPTION
### :newspaper: PR description

The state when the perforator is shutting down is ambigously logged. Adding a shutdown hook that waits for the connections to be cleaned up makes the logs more explicit.

### :memo: Reviewer instructions

<!--
Provide indications to the reviewer:
- where should he start?
- are their changes that are side effects to the original PR objective?
-->
