### PR TITLE
Timed futures for slow poll detection

### DIFF
--- a/chappy/perforator/src/perforator.rs
+++ b/chappy/perforator/src/perforator.rs
@@ -5,6 +5,7 @@ use crate::{
     shutdown::ShutdownGuard,
 };
 use chappy_seed::{Address, AddressConv};
+use chappy_util::timed_poll::timed_poll;
 use chappy_util::{awaitable_map::AwaitableMap, protocol::ParsedTcpStream};
 use futures::StreamExt;
 use std::net::Ipv4Addr;
@@ -12,7 +13,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::timeout;
-use tracing::{debug, debug_span, instrument};
+use tracing::{debug, debug_span, instrument, Instrument};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct TargetVirtualAddress {
@@ -70,9 +71,14 @@ impl Perforator {
             ip: tgt_virt,
             port: tgt_port,
         };
+
         self.port_mappings.insert(src_port, virtual_addr.clone());
         // TODO bind only once per target virtual IP
-        let punch_resp = self.binding_service.bind_client(tgt_virt.to_string()).await;
+        let punch_resp = timed_poll(
+            "bind_client",
+            self.binding_service.bind_client(tgt_virt.to_string()),
+        )
+        .await;
         let natted_addr = punch_resp.target_nated_addr.unwrap();
         self.address_mappings.insert(
             virtual_addr,
@@ -82,13 +88,15 @@ impl Perforator {
                 certificate_der: punch_resp.server_certificate.clone(),
             },
         );
-        self.forwarder
-            .try_target(
+        timed_poll(
+            "try_target",
+            self.forwarder.try_target(
                 AddressConv(natted_addr).into(),
                 tgt_port,
                 punch_resp.server_certificate,
-            )
-            .await?;
+            ),
+        )
+        .await?;
         debug!(duration = ?start.elapsed(), "completed");
         Ok(())
     }
@@ -142,7 +150,6 @@ impl Perforator {
             let stream = binding_service.bind_server(server_certificate).await;
             // For each incoming server punch request, send a random packet to punch
             // a hole in the NAT
-            debug!("subscribe to hole punching requests");
             stream
                 .map(|punch_req| {
                     let punch_req = punch_req.unwrap();
@@ -155,8 +162,8 @@ impl Perforator {
                 .buffer_unordered(usize::MAX)
                 .take_until(punch_stream_shdn_guard.wait_shutdown())
                 .for_each(|_| async {})
+                .instrument(debug_span!("punch_stream"))
                 .await;
-            debug!("subscription to hole punching requests closed");
         });
         debug!("completed");
         node_binding
@@ -184,10 +191,13 @@ impl Perforator {
                             target_port,
                             response_writer,
                         } => {
-                            let reg_fut = perforator.register_client(
-                                source_port,
-                                target_virtual_ip,
-                                target_port,
+                            let reg_fut = timed_poll(
+                                "register_client",
+                                perforator.register_client(
+                                    source_port,
+                                    target_virtual_ip,
+                                    target_port,
+                                ),
                             );
                             match reg_fut.await {
                                 Ok(_) => response_writer.write_success().await,
@@ -195,7 +205,7 @@ impl Perforator {
                             };
                         }
                         ParsedTcpStream::Raw(stream) => {
-                            perforator.forward_conn(stream).await;
+                            timed_poll("forward_conn", perforator.forward_conn(stream)).await;
                         }
                     }
                 },

--- a/chappy/perforator/src/perforator.rs
+++ b/chappy/perforator/src/perforator.rs
@@ -97,7 +97,7 @@ impl Perforator {
     #[instrument(name = "fwd_conn", skip_all)]
     async fn forward_conn(&self, stream: TcpStream) {
         debug!("starting...");
-        // TODO adjust timout duration
+        // TODO adjust timeout duration
         let src_port = stream.peer_addr().unwrap().port();
         let target_virtual_address = timeout(
             Duration::from_secs(1),
@@ -105,7 +105,7 @@ impl Perforator {
         )
         .await
         .unwrap();
-        // TODO adjust timout duration
+        // TODO adjust timeout duration
         let target_address = timeout(
             Duration::from_secs(3),
             self.address_mappings.get(target_virtual_address, |_| false),
@@ -191,7 +191,7 @@ impl Perforator {
                             );
                             match reg_fut.await {
                                 Ok(_) => response_writer.write_success().await,
-                                Err(_) => response_writer.write_success().await,
+                                Err(_) => response_writer.write_failure().await,
                             };
                         }
                         ParsedTcpStream::Raw(stream) => {

--- a/chappy/perforator/src/shutdown.rs
+++ b/chappy/perforator/src/shutdown.rs
@@ -1,3 +1,4 @@
+use chappy_util::timed_poll::timed_poll;
 use futures::{Future, FutureExt};
 use std::fmt;
 use std::time::Duration;
@@ -14,11 +15,14 @@ pub struct ShutdownGuard {
 impl ShutdownGuard {
     /// Wait for the shutdown signal
     pub async fn wait_shutdown(&mut self) {
-        while self.is_shutdown.changed().await.is_ok() {
-            if *self.is_shutdown.borrow() {
-                break;
+        timed_poll("wait_shutdown", async {
+            while self.is_shutdown.changed().await.is_ok() {
+                if *self.is_shutdown.borrow() {
+                    break;
+                }
             }
-        }
+        })
+        .await
     }
 
     /// Run the provided future until completion or a shutdown notification is

--- a/chappy/seed/src/registered_endpoints.rs
+++ b/chappy/seed/src/registered_endpoints.rs
@@ -37,12 +37,12 @@ impl RegisteredEndpoints {
             cluster_id: cluster_id.to_owned(),
         };
 
-        // TODO adjust timout duration
+        // TODO adjust timeout duration
         let resolved_target_timeout = timeout(
             Duration::from_secs(10),
             self.0.get(virtual_target_key, |prev_tgt| {
                 if prev_tgt.punch_req_stream.is_closed() {
-                    info!(ip = tgt_ip, cluster_id, "replace closed target");
+                    info!(ip = tgt_ip, cluster_id, "reset closed target first");
                     true
                 } else {
                     false

--- a/chappy/util/src/awaitable_map.rs
+++ b/chappy/util/src/awaitable_map.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::Mutex;
 use tokio::sync::watch;
-use tracing::debug_span;
+use tracing::trace_span;
 
 /// A map where values can be asynchronously be awaited.
 pub struct AwaitableMap<K, V> {
@@ -30,7 +30,7 @@ where
     where
         F: FnOnce(V) -> bool,
     {
-        let mut rx = debug_span!("lock", src = "AwaitableMap.get").in_scope(|| {
+        let mut rx = trace_span!("lock", src = "AwaitableMap.get").in_scope(|| {
             let mut guard = self.inner.lock().unwrap();
             if let Some(value_tx) = guard.get(&key) {
                 let current_val = value_tx.subscribe().borrow().clone();
@@ -53,7 +53,7 @@ where
 
     /// Insert the key/value pair, and returns the existing value if any
     pub fn insert(&self, key: K, value: V) -> Option<V> {
-        debug_span!("lock", src = "AwaitableMap.insert").in_scope(|| {
+        trace_span!("lock", src = "AwaitableMap.insert").in_scope(|| {
             let mut guard = self.inner.lock().unwrap();
             if let Some(target_tx) = guard.get(&key) {
                 target_tx.send_replace(Some(value))

--- a/chappy/util/src/lib.rs
+++ b/chappy/util/src/lib.rs
@@ -2,6 +2,7 @@ pub mod awaitable_map;
 pub mod protocol;
 pub mod tcp_connect;
 pub mod test;
+pub mod timed_poll;
 mod tracing_helpers;
 
 pub use tracing_helpers::{close_tracing, init_tracing, init_tracing_shared_lib};

--- a/chappy/util/src/protocol.rs
+++ b/chappy/util/src/protocol.rs
@@ -1,5 +1,6 @@
 /// Protocol talked between the interceptor and the perforator
 use crate::tcp_connect::connect_retry;
+use crate::timed_poll::timed_poll;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult};
 use std::net::Ipv4Addr;
 use std::time::Duration;
@@ -46,13 +47,19 @@ pub struct ResponseWriter(TcpStream);
 
 impl ResponseWriter {
     pub async fn write_success(mut self) {
-        self.0.write_u8(0).await.unwrap();
-        self.0.flush().await.unwrap();
+        timed_poll("resp_success", async {
+            self.0.write_u8(0).await.unwrap();
+            self.0.flush().await.unwrap();
+        })
+        .await;
     }
 
     pub async fn write_failure(mut self) {
-        self.0.write_u8(1).await.unwrap();
-        self.0.flush().await.unwrap();
+        timed_poll("resp_failure", async {
+            self.0.write_u8(1).await.unwrap();
+            self.0.flush().await.unwrap();
+        })
+        .await;
     }
 }
 

--- a/chappy/util/src/tcp_connect.rs
+++ b/chappy/util/src/tcp_connect.rs
@@ -3,30 +3,35 @@ use std::time::{Duration, Instant};
 use tokio::net::{TcpStream, ToSocketAddrs};
 use tracing::{error, warn};
 
+use crate::timed_poll::timed_poll;
+
 /// Due to cloud function provisioning and setup times, the target addresses
 /// might not be available right way. This helper helps bridge that gap by
 /// retrying a TCP connection for the specified duration.
 pub async fn connect_retry<A: ToSocketAddrs>(addr: A, timeout: Duration) -> IoResult<TcpStream> {
-    let start = Instant::now();
-    let mut backoff = 0;
-    let mut first = true;
-    loop {
-        match TcpStream::connect(&addr).await {
-            Ok(stream) => return Ok(stream),
-            Err(err) if err.kind() == IoErrorKind::ConnectionRefused => {
-                if start.elapsed() > timeout {
-                    error!("TCP connection and retries refused");
-                    return Err(err);
+    timed_poll("tcp_conn", async {
+        let start = Instant::now();
+        let mut backoff = 0;
+        let mut first = true;
+        loop {
+            match TcpStream::connect(&addr).await {
+                Ok(stream) => return Ok(stream),
+                Err(err) if err.kind() == IoErrorKind::ConnectionRefused => {
+                    if start.elapsed() > timeout {
+                        error!("TCP connection and retries refused");
+                        return Err(err);
+                    }
+                    if first {
+                        warn!("TCP connection refused, retrying with linear backoff...");
+                        first = false;
+                    }
+                    tokio::time::sleep(Duration::from_millis(20 + backoff)).await;
+                    backoff += 5;
+                    continue;
                 }
-                if first {
-                    warn!("TCP connection refused, retrying with linear backoff...");
-                    first = false;
-                }
-                tokio::time::sleep(Duration::from_millis(20 + backoff)).await;
-                backoff += 5;
-                continue;
+                Err(err) => return Err(err),
             }
-            Err(err) => return Err(err),
         }
-    }
+    })
+    .await
 }

--- a/chappy/util/src/timed_poll.rs
+++ b/chappy/util/src/timed_poll.rs
@@ -1,0 +1,41 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use tracing::{debug, error, warn};
+
+pub struct TimedPoll<F> {
+    future: F,
+    tag: &'static str,
+}
+
+pub fn timed_poll<F: Future>(tag: &'static str, future: F) -> TimedPoll<F> {
+    TimedPoll { future, tag }
+}
+
+impl<F: Future> Future for TimedPoll<F> {
+    type Output = F::Output;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<F::Output> {
+        let before = std::time::Instant::now();
+        let tag = self.tag;
+        let future = unsafe { Pin::map_unchecked_mut(self, |me| &mut me.future) };
+        let res = future.poll(cx);
+        let poll_duration = before.elapsed();
+        if poll_duration > Duration::from_secs(1) {
+            debug!(elapsed = ?poll_duration, tag, "slow poll");
+        }
+        res
+    }
+}
+
+pub fn timed_drop<F: Sized>(tag: &'static str, obj: F) {
+    let handle = tokio::task::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        warn!(tag, "slow drop 10ms");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        error!(tag, "slow drop 1s");
+    });
+    drop(obj);
+    handle.abort();
+}


### PR DESCRIPTION
### :newspaper: PR description

Measuring poll duration for further troubleshooting.

Outcomes:
- slow polls occur a little bit everywhere
- even when the future tree is consistently instrumented, some slow polls are not traced to the root
  - e.g: `try_target` has all its futures wrapped with `timed_poll`, yet often logs only contain 
```
15:28:16.958 DEBUG perforator{virt_ip="172.28.0.8"}:tcp_srv:tcp_conn{src_port=57282}:reg_cli{src_port=50137 tgt_virt=172.28.0.16 tgt_port=8080}: chappy_util::timed_poll: slow poll elapsed=38.815467338s tag="try_target"
15:28:16.958 DEBUG perforator{virt_ip="172.28.0.8"}:tcp_srv:tcp_conn{src_port=57282}:reg_cli{src_port=50137 tgt_virt=172.28.0.16 tgt_port=8080}: chappy_perforator::perforator: completed duration=38.821848142s
15:28:16.958 DEBUG perforator{virt_ip="172.28.0.8"}:tcp_srv:tcp_conn{src_port=57282}: chappy_util::timed_poll: slow poll elapsed=38.815521119s tag="register_client"
15:28:16.958 DEBUG perforator{virt_ip="172.28.0.8"}:tcp_srv:tcp_conn{src_port=57282}: chappy_util::timed_poll: slow poll elapsed=38.815575702s tag="spawn"
```
### :memo: Reviewer instructions

<!--
Provide indications to the reviewer:
- where should he start?
- are their changes that are side effects to the original PR objective?
-->
